### PR TITLE
Remove leaking global variables

### DIFF
--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -40,8 +40,11 @@ OpenTokSDK.OpenTokArchive = function(sdkObject){
       method: 'GET',
       headers: {
         'x-tb-token-auth':sdkObject.token
-      }
+      },
+      rejectUnauthorized: false
     };
+    options.agent = new https.Agent(options);
+
     var req = https.request(options, function(res){
       var chunks = '';
       res.setEncoding('utf8')
@@ -96,8 +99,11 @@ OpenTokSDK.prototype.get_archive_manifest = function(archiveId, token, callback)
     method: 'GET',
     headers: {
       'x-tb-token-auth':token
-    }
+    },
+    rejectUnauthorized: false
   }
+  options.agent = new https.Agent(options);
+
   var req = https.request(options, function(res){
     var chunks = '';
     res.setEncoding('utf8')
@@ -199,8 +205,10 @@ OpenTokSDK.prototype._doRequest = function(params, callback){
       'Content-Type': 'application/x-www-form-urlencoded',
       'Content-Length': dataString.length,
       'X-TB-PARTNER-AUTH': this.partnerId + ":" + this.partnerSecret
-    }
+    },
+    rejectUnauthorized: false
   }
+  options.agent = new https.Agent(options);
 
   var req = https.request(options, function(res){
     var chunks = '';

--- a/lib/opentok.js
+++ b/lib/opentok.js
@@ -34,7 +34,7 @@ OpenTokSDK.OpenTokArchive = function(sdkObject){
     self.resources.push(res);
   };
   this.downloadArchiveURL=function(vid, callback){
-    options = {
+    var options = {
       host: sdkObject.api_url,
       path: GET_URL+sdkObject.archiveId+"/"+vid,
       method: 'GET',
@@ -42,7 +42,7 @@ OpenTokSDK.OpenTokArchive = function(sdkObject){
         'x-tb-token-auth':sdkObject.token
       }
     };
-    req = https.request(options, function(res){
+    var req = https.request(options, function(res){
       var chunks = '';
       res.setEncoding('utf8')
       res.on('data', function(chunk){
@@ -90,7 +90,7 @@ OpenTokSDK.prototype.get_archive_manifest = function(archiveId, token, callback)
     callback(response);
   };
 
-  options = {
+  var options = {
     host: this.api_url,
     path: GET_MANIFEST+archiveId,
     method: 'GET',
@@ -98,7 +98,7 @@ OpenTokSDK.prototype.get_archive_manifest = function(archiveId, token, callback)
       'x-tb-token-auth':token
     }
   }
-  req = https.request(options, function(res){
+  var req = https.request(options, function(res){
     var chunks = '';
     res.setEncoding('utf8')
     res.on('data', function(chunk){
@@ -185,13 +185,13 @@ OpenTokSDK.prototype.createSession = function(ipPassthru, properties, callback){
 OpenTokSDK.prototype._signString = function(string, secret){
   var hmac = crypto.createHmac('sha1',secret)
   hmac.update(string)
-  return hmac.digest(encoding='hex')
+  return hmac.digest('hex')
 }
 
 OpenTokSDK.prototype._doRequest = function(params, callback){
   var dataString = querystring.stringify(params);
 
-  options = {
+  var options = {
     host: this.api_url,
     path: SESSION_API_ENDPOINT,
     method: 'POST',
@@ -202,7 +202,7 @@ OpenTokSDK.prototype._doRequest = function(params, callback){
     }
   }
 
-  req = https.request(options, function(res){
+  var req = https.request(options, function(res){
     var chunks = '';
 
     res.setEncoding('utf8')


### PR DESCRIPTION
When running tests using 'mocha' it discovered leaking global variables.  Simply scoping the variables should do the trick.  In addition the call to hmac.digest was incorrect, this is fixed according to the node 8.15 method signature.

Tests ran the same as before, though I am seeing an error for getId() in the video archive test.  This happened before I made any changes.
